### PR TITLE
Classmap+homepage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "module",
         "developer tool"
     ],
-    
+    "homepage": "https://github.com/ThaDafinser/ThaConfigalyzer",
     "authors": [{
         "name": "Martin Keckeis",
         "email": "martin.keckeis1@gmail.com"
@@ -27,7 +27,10 @@
     
     "autoload": {
         "psr-0": {
-            "ThaConfigalyzer\\": "src/"
-        }
+            "ThaConfigalyzer": "src/"
+        },
+        "classmap": [
+            "./Module.php"
+        ]
     }
 }


### PR DESCRIPTION
This fix corrects the bug after **composer update** .

Without this patch, you can just add (after composer update) this line into _vendor/composer/autoload_classmap.php_

```
       'ThaConfigalyzer\\Module' => $vendorDir . '/thadafinser/tha-configalyzer/Module.php',
```
